### PR TITLE
Remove default margin-top in footer

### DIFF
--- a/sass/components/_global.scss
+++ b/sass/components/_global.scss
@@ -272,7 +272,6 @@ ul.staggered-list li {
 
 // Footer
 footer.page-footer {
-  margin-top: 20px;
   padding-top: 20px;
   background-color: $footer-bg-color;
 


### PR DESCRIPTION
This default margin-top in the footer is not working well. I personally prefer to handle vertical margins in other terms (than just a 20px). It should be at least configurable
